### PR TITLE
Add Dockerfiles and central compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # Inlaze Task Manager
+
+This repository contains a small microservices stack with a Next.js front end. Each service can be run locally using Docker.
+
+## Running the whole stack
+
+1. Install Docker and Docker Compose.
+2. From the project root run:
+
+```bash
+docker compose up --build
+```
+
+The compose file builds each service from its own `Dockerfile` and starts the required dependencies such as PostgreSQL and RabbitMQ. The front end will be available on [http://localhost:3003](http://localhost:3003).

--- a/backend/auth/Dockerfile
+++ b/backend/auth/Dockerfile
@@ -1,0 +1,17 @@
+# Production-ready Dockerfile for auth service
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY tsconfig*.json nest-cli.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY package*.json ./
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["node", "dist/main.js"]

--- a/backend/projects/Dockerfile
+++ b/backend/projects/Dockerfile
@@ -1,0 +1,17 @@
+# Production-ready Dockerfile for projects service
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY tsconfig*.json nest-cli.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY package*.json ./
+ENV NODE_ENV=production
+EXPOSE 3001
+CMD ["node", "dist/main.js"]

--- a/backend/tasks/Dockerfile
+++ b/backend/tasks/Dockerfile
@@ -1,0 +1,17 @@
+# Production-ready Dockerfile for tasks service
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY tsconfig*.json nest-cli.json ./
+COPY src ./src
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/dist ./dist
+COPY package*.json ./
+ENV NODE_ENV=production
+EXPOSE 3002
+CMD ["node", "dist/main.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,67 @@
+version: '3.8'
+
+services:
+  auth:
+    build: ./backend/auth
+    env_file:
+      - ./backend/auth/.env
+    depends_on:
+      - db
+    ports:
+      - "3000:3000"
+
+  projects:
+    build: ./backend/projects
+    env_file:
+      - ./backend/projects/.env
+    depends_on:
+      - db
+    ports:
+      - "3001:3001"
+
+  tasks:
+    build: ./backend/tasks
+    env_file:
+      - ./backend/tasks/.env
+    depends_on:
+      - db
+      - rabbitmq
+    ports:
+      - "3002:3002"
+
+  notifications:
+    build: ./backend/notifications
+    env_file:
+      - ./backend/notifications/.env
+    depends_on:
+      - rabbitmq
+    ports:
+      - "3004:3004"
+
+  frontend:
+    build: ./frontend
+    env_file:
+      - ./frontend/.env.local
+    depends_on:
+      - auth
+    ports:
+      - "3003:3000"
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: pass
+      POSTGRES_DB: postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+      - ./infra/db-init.sql:/docker-entrypoint-initdb.d/init.sql:ro
+
+volumes:
+  db_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,17 @@
+# Production-ready Dockerfile for frontend Next.js app
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/package*.json ./
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/infra/db-init.sql
+++ b/infra/db-init.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE inlaze;
+CREATE DATABASE inlaze_auth;
+CREATE DATABASE inlaze_projects;


### PR DESCRIPTION
## Summary
- add Dockerfile for each backend service and the frontend
- setup a database init script
- create a root `docker-compose.yml` that builds all services
- document how to run the stack

## Testing
- `git status --short`


------
