### PR TITLE
Fix RabbitMQ config in notifications service

### DIFF
--- a/backend/notifications/package.json
+++ b/backend/notifications/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
+    "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/event-emitter": "^3.0.1",
     "@nestjs/microservices": "^11.1.3",

--- a/backend/notifications/src/main.ts
+++ b/backend/notifications/src/main.ts
@@ -10,8 +10,8 @@ async function bootstrap() {
   app.connectMicroservice<MicroserviceOptions>({
     transport: Transport.RMQ,
     options: {
-      urls: [config.get<string>('rabbitmq.url')],
-      queue: config.get<string>('rabbitmq.queue'),
+      urls: [config.get<string>('rabbitmq.url', 'amqp://localhost:5672')],
+      queue: config.get<string>('rabbitmq.queue', 'notifications_queue'),
       queueOptions: { durable: true },
       noAck: false,
     },


### PR DESCRIPTION
## Summary
- ensure RabbitMQ connection strings are strings
- add `@nestjs/config` dependency for notifications service

## Testing
- `npm run build` *(fails: Cannot find module '@nestjs/websockets')*

------