### PR TITLE
Fix provider usage in layout

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,11 +1,8 @@
 import type { Metadata } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import './globals.css';
-import { NextUIProvider } from '@nextui-org/react';
-import { theme } from '@/styles/themes';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { SocketToast } from '@/components/feedback/Toast';
 import { ReactNode } from 'react';
+import Providers from './providers';
 
 const geistSans = Geist({ variable: '--font-geist-sans', subsets: ['latin'] });
 const geistMono = Geist_Mono({ variable: '--font-geist-mono', subsets: ['latin'] });
@@ -15,18 +12,11 @@ export const metadata: Metadata = {
   description: 'Dashboard',
 };
 
-const queryClient = new QueryClient();
-
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <QueryClientProvider client={queryClient}>
-          <NextUIProvider theme={theme}>
-            {children}
-            <SocketToast />
-          </NextUIProvider>
-        </QueryClientProvider>
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { ReactNode, useState } from 'react';
+import { NextUIProvider } from '@nextui-org/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { theme } from '@/styles/themes';
+import { SocketToast } from '@/components/feedback/Toast';
+
+export default function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+  return (
+    <QueryClientProvider client={queryClient}>
+      <NextUIProvider theme={theme}>
+        {children}
+        <SocketToast />
+      </NextUIProvider>
+    </QueryClientProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- create client Providers wrapper for React Query and NextUI
- use the Providers component in the root layout

## Testing
- `npm run lint`
- `npm test`


------