### PR TITLE
Fix layout metadata issue

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,33 +1,22 @@
-import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
-import './globals.css';
-import { NextUIProvider } from '@nextui-org/react';
-import { theme } from '@/styles/themes';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { SocketToast } from '@/components/feedback/Toast';
-import { ReactNode } from 'react';
+import './globals.css'
+import { Geist_Mono } from 'next/font/google'
+import { Providers } from '@/components/Providers'
 
-const geistSans = Geist({ variable: '--font-geist-sans', subsets: ['latin'] });
-const geistMono = Geist_Mono({ variable: '--font-geist-mono', subsets: ['latin'] });
+const geistMono = Geist_Mono({ variable: '--font-geist-mono', subsets: ['latin'] })
 
 export const metadata: Metadata = {
   title: 'Inlaze Task Manager',
   description: 'Dashboard',
-};
+}
 
-const queryClient = new QueryClient();
-
-export default function RootLayout({ children }: { children: ReactNode }) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
-        <QueryClientProvider client={queryClient}>
-          <NextUIProvider theme={theme}>
-            {children}
-            <SocketToast />
-          </NextUIProvider>
-        </QueryClientProvider>
+      <body className={geistMono.variable}>
+        <Providers>
+          {children}
+        </Providers>
       </body>
     </html>
-  );
+  )
 }

--- a/frontend/src/components/Providers.tsx
+++ b/frontend/src/components/Providers.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { ReactNode } from 'react'
+import { NextUIProvider } from '@nextui-org/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { SocketToast } from '@/components/feedback/Toast'
+import { theme } from '@/styles/themes'
+
+const queryClient = new QueryClient()
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <NextUIProvider theme={theme}>
+      <QueryClientProvider client={queryClient}>
+        {children}
+        <SocketToast />
+      </QueryClientProvider>
+    </NextUIProvider>
+  )
+}


### PR DESCRIPTION
## Summary
- create a client `Providers` component for NextUI and React Query
- use `Providers` in `layout.tsx` so metadata can be exported

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------