### PR TITLE
Add user registration page

### DIFF
--- a/frontend/src/app/(public)/register/page.tsx
+++ b/frontend/src/app/(public)/register/page.tsx
@@ -1,21 +1,19 @@
 'use client';
-import { useLogin } from '@/features/auth/hooks';
+import { useRegister } from '@/features/auth/hooks';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { FormEvent, useState } from 'react';
 
-export default function LoginPage() {
+export default function RegisterPage() {
   const router = useRouter();
-  const login = useLogin();
+  const register = useRegister();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
 
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    const res = await login.mutateAsync({ email, password });
-    if (res?.accessToken) {
-      router.push('/dashboard');
-    }
+    await register.mutateAsync({ email, password });
+    router.push('/login');
   };
 
   return (
@@ -35,10 +33,10 @@ export default function LoginPage() {
         className="border p-2"
       />
       <button type="submit" className="bg-blue-500 text-white p-2 rounded">
-        Login
+        Register
       </button>
       <p className="text-center">
-        Don't have an account? <Link href="/register">Register</Link>
+        Already have an account? <Link href="/login">Login</Link>
       </p>
     </form>
   );

--- a/frontend/src/features/auth/api.ts
+++ b/frontend/src/features/auth/api.ts
@@ -8,3 +8,11 @@ export const login = async (email: string, password: string) => {
   });
   return data;
 };
+
+export const register = async (email: string, password: string) => {
+  const { data } = await api.post(`${API_PREFIX}/auth/register`, {
+    email,
+    password,
+  });
+  return data;
+};

--- a/frontend/src/features/auth/hooks.ts
+++ b/frontend/src/features/auth/hooks.ts
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { login } from './api';
+import { login, register } from './api';
 import { useAuth } from '@/store/authSlice';
 
 export const useLogin = () => {
@@ -12,5 +12,12 @@ export const useLogin = () => {
         setToken(data.accessToken);
       }
     },
+  });
+};
+
+export const useRegister = () => {
+  return useMutation({
+    mutationFn: (data: { email: string; password: string }) =>
+      register(data.email, data.password),
   });
 };


### PR DESCRIPTION
## Summary
- support registering users from frontend
- expose register API and hook
- add public register page
- link register from login page

## Testing
- `npm test --silent` in `frontend`
- `npm test --silent -- --passWithNoTests` in `backend/auth`


------
https://chatgpt.com/codex/tasks/task_e_68704612b9d88327842aa3bc7f01ceb5